### PR TITLE
update README and workshop guide with detailed google cloud auth setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,66 +47,27 @@ timesheet-agent-workshop/
 │       ├── database_tools.py # Tools for interacting with the timesheet database
 │       └── datetime_tools.py # Tools for date and time operations
 ├── requirements.txt          # Python package dependencies
+├── workshop.md               # Step-by-step setup guide
 └── README.md                 # This file
 ```
 
-## Setup and Installation
+## 🚀 Quick Start
 
-1.  **Prerequisites:**
-    *   Python 3.8 or higher
-    *   Git
+For detailed setup and installation instructions, see the **[Workshop Guide](workshop.md)**.
 
-2.  **Clone the Repository:**
-    ```bash
-    git clone https://github.com/yashmehta10/timesheet-agent-workshop.git
-    cd timesheet-agent-workshop
-    ```
+The workshop includes:
+- ✅ Prerequisites and authentication setup  
+- ✅ Step-by-step installation for all platforms
+- ✅ Environment configuration
+- ✅ Database initialization
+- ✅ Troubleshooting guide
 
-3.  **Create and Activate a Virtual Environment (Recommended):**
-    ```bash
-    python3 -m venv venv
-    source venv/bin/activate  # On Windows: venv\Scripts\activate
-    ```
+### Quick Overview:
+1. **Prerequisites:** Python 3.8+, Git, Google Cloud authentication
+2. **Install:** Clone repo → Create venv → Install dependencies → Configure environment
+3. **Run:** `adk web` → Access at `http://localhost:8000`
 
-4.  **Install Dependencies:**
-    ```bash
-    pip install -r requirements.txt
-    ```
-
-5.  **Set Up Environment Variables:**
-    Create a `.env` file in the `timesheet_agent/` directory (or configure environment variables directly in your deployment environment). You can use `timesheet_agent/.env.local` as a template.
-    ```env
-    # timesheet_agent/.env
-    GOOGLE_GENAI_USE_VERTEXAI=true # Or false, depending on your setup
-    GOOGLE_CLOUD_PROJECT="your-gcp-project-id" # If using Vertex AI
-    GOOGLE_CLOUD_LOCATION="your-gcp-location"  # If using Vertex AI
-    TIMESHEET_DB_PATH="timesheet_agent/database/timesheet.db" # Path to your SQLite database
-    ```
-    *   `GOOGLE_GENAI_USE_VERTEXAI`: Set to `true` or `false` depending on whether you are using Vertex AI for the Gemini model.
-    *   `GOOGLE_CLOUD_PROJECT`: Your Google Cloud Project ID (if using Vertex AI).
-    *   `GOOGLE_CLOUD_LOCATION`: Your Google Cloud Location (if using Vertex AI).
-    *   `TIMESHEET_DB_PATH`: The absolute or relative path to the SQLite database file. The default in `.env.local` points to `timesheet_agent/database/timesheet.db`.
-
-6.  **Initialize the Database:**
-    The database schema and sample data can be created by running the `timesheet_agent/database/sql/timesheet_schema.sql` script using a SQLite client.
-    For example, using the `sqlite3` CLI:
-    ```bash
-    sqlite3 timesheet_agent/database/timesheet.db < timesheet_agent/database/sql/timesheet_schema.sql
-    ```
-    This will create the necessary tables (`employees`, `projects`, `assignments`, `timesheets`) and populate them with initial sample data. Ensure the path specified by `TIMESHEET_DB_PATH` matches where you create the database.
-
-## Running the Agent
-
-The agent is built using the Google Agent Development Kit (ADK).
-
-The main agent definition is in `timesheet_agent/agent.py`.
-
-To run the agent locally in a web-based playground environment provided by the ADK, navigate to the root directory of the project (`timesheet-agent-workshop/`) in your terminal (ensure your virtual environment is activated and environment variables from `timesheet_agent/.env` are loaded or set) and run:
-
-```bash
-adk web
-```
-This command will start a local server, and you can typically access the playground by opening `http://127.0.0.1:8000` (or the address shown in your terminal) in your web browser. You can then interact with your `timesheet_agent`.
+**👉 [Start with the Workshop Guide →](workshop.md)**
 
 ## Agent Functionality
 
@@ -170,4 +131,6 @@ When contributing, please ensure:
 
 ---
 
-This README provides a starting point. You can expand on sections like "Running the Agent" with specific ADK commands once you have them, or add a "Troubleshooting" section as needed.
+## 📖 Documentation
+
+- **[Workshop Guide](workshop.md)** - Complete setup and installation instructions

--- a/workshop.md
+++ b/workshop.md
@@ -6,15 +6,72 @@ This runsheet includes the essential commands and steps required to run the time
 
 ## ✅ Prerequisites
 
-- Python 3.8+
-- Google CLoud SDK
-- Git
-- ADK CLI installed (`pip install google-adk`)
+- **Python 3.8+** (required to run the agent)
+- **Git** (to clone the repository)
+- **Google Cloud Authentication** (required for Vertex AI access)
 
-OR
+**Note:** If you're using **Google Cloud Shell**, it comes with Python, Git, and gcloud CLI pre-installed and pre-authenticated.
 
-- Google Cloud Shell 
 ---
+
+## 🔐 Google Cloud Authentication Setup
+
+<details>
+<summary><strong>⚠️ IMPORTANT: Authentication Required</strong> - Click to expand authentication options</summary>
+
+**By default this agent uses Vertex AI API and requires Google Cloud authentication. Choose ONE of the following methods:**
+
+### Option 1: Google Cloud SDK (Recommended)
+
+#### Installation:
+```bash
+# macOS with Homebrew:
+brew install google-cloud-sdk
+
+# Windows with Chocolatey:
+choco install gcloudsdk
+
+# Windows with Scoop:
+scoop bucket add extras
+scoop install gcloud
+
+# Or download installer from: https://cloud.google.com/sdk/docs/install
+```
+
+#### Authentication:
+```bash
+# Authenticate with Google Cloud
+gcloud auth application-default login
+
+# Set your project (replace with your actual project ID)
+gcloud config set project YOUR_PROJECT_ID
+```
+
+### Option 2: Service Account Key File
+1. Create a service account in Google Cloud Console
+2. Download the JSON key file
+3. Set the environment variable:
+
+**Linux/macOS:**
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS="/path/to/your/service-account-key.json"
+```
+
+**Windows (Command Prompt):**
+```cmd
+set GOOGLE_APPLICATION_CREDENTIALS=C:\path\to\your\service-account-key.json
+```
+
+**Windows (PowerShell):**
+```powershell
+$env:GOOGLE_APPLICATION_CREDENTIALS="C:\path\to\your\service-account-key.json"
+```
+
+### Option 3: Workload Identity Federation
+For enterprise environments using external identity providers, follow the [Workload Identity Federation guide](https://cloud.google.com/iam/docs/workload-identity-federation).
+
+</details>
+
 
 ## 📥 Clone the Repository
 
@@ -35,30 +92,57 @@ pip install -r requirements.txt
 ```
 
 ## ⚙️ Set Environment Variables
-Create a file at timesheet_agent/.env based on .env.local file: Ensure you add your GOOGLE_CLOUD_PROJECT
+Create a file at `timesheet_agent/.env` based on the template below. **Ensure you add your actual GOOGLE_CLOUD_PROJECT ID**:
 
 ```
 GOOGLE_GENAI_USE_VERTEXAI=TRUE
-GOOGLE_CLOUD_PROJECT=
+GOOGLE_CLOUD_PROJECT={your-actual-project-id}
 GOOGLE_CLOUD_LOCATION=us-central1
 TIMESHEET_DB_PATH=timesheet_agent/database/timesheet.db
 ```
 
+**🔍 How to find your Project ID:**
+- Google Cloud Console: Look at the top of any GCP page
+- Command line: `gcloud config get-value project`
+
 ## 🛠️ Initialize the SQLite Database
-If you want to customise, `update timesheet_schema.sql` file
-```
+If you want to customize, update the `timesheet_schema.sql` file:
+```sql
 INSERT INTO employees (first_name, last_name, email) VALUES
 ('<your first name>', '<your last name>', '<your email>');  -- employee_id will be 1
 ```
 
+### Initialize Database
+
 ```bash
+# Initialize database schema and sample data
 cd timesheet_agent/database
-sqlite3 timesheet.db < sql/timesheet_schema.sql
-sqlite3 timesheet.db < sql/read_data.sql
+sqlite3 timesheet.db < sql/timesheet_schema.sql  # Creates tables and relationships
+sqlite3 timesheet.db < sql/read_data.sql         # Inserts sample data for employees, projects, and assignments
 ```
+📖 **Detailed schema:** See `timesheet_agent/database/sql/timesheet_schema.sql` for complete schema definitions, constraints, and sample data.
 
 ## 🚀 Run the Agent Locally
-Navigate to the root directory under (timesheet-agent-workshop) using `cd ../..` if you are still in the database folder.
+Navigate to the root directory (timesheet-agent-workshop) using `cd ../..` if you are still in the database folder.
 ```bash
 adk web
 ```
+
+## 🔧 Troubleshooting
+
+### Authentication Errors
+If you see errors like "DefaultCredentialsError" or "Your default credentials were not found":
+
+1. **Verify authentication**: `gcloud auth list`
+2. **Re-authenticate**: `gcloud auth application-default login`
+3. **Check project setting**: `gcloud config get-value project`
+4. **Verify environment variables**: Check your `.env` file has the correct project ID
+
+### Common Issues
+- **Missing project ID**: Ensure `GOOGLE_CLOUD_PROJECT` in `.env` matches your actual GCP project
+- **Vertex AI not enabled**: Enable the Vertex AI API in your Google Cloud project
+- **Billing not enabled**: Ensure billing is enabled for your Google Cloud project
+
+---
+
+**🎯 Ready to go!** Your timesheet agent should now be running at `http://localhost:8000`


### PR DESCRIPTION
I think this is where a bunch of the audience got tripped up.
Setup instructions assumed that the shell session is already authenticated with google cloud (I wasn't, and neither were the folks around me)